### PR TITLE
Plugin content_view_version timeout increase

### DIFF
--- a/plugins/modules/content_view_version.py
+++ b/plugins/modules/content_view_version.py
@@ -203,7 +203,7 @@ def main():
         mutually_exclusive=[['current_lifecycle_environment', 'version']],
     )
 
-    module.task_timeout = 60 * 60
+    module.task_timeout = 180 * 60
 
     if 'version' in module.foreman_params and not re.match(r'^\d+\.\d+$', module.foreman_params['version']):
         try:


### PR DESCRIPTION
In specific content views which are using filters publish or promote may exceed task_timeout. Proposing update from 60 * 60 to 180 * 60.