### PR TITLE
allow setting an alternative password for auth sources

### DIFF
--- a/tests/test_playbooks/auth_source_ldap.yml
+++ b/tests/test_playbooks/auth_source_ldap.yml
@@ -31,7 +31,8 @@
     - include_tasks: tasks/auth_source_ldap.yml
       vars:
         auth_source_ldap_state: present
-        auth_source_ldap_account_password: changeme
+        # we only set this once at creation, as otherwise idempotency tests would fail
+        auth_source_ldap_account_password: "{{ default_auth_source_ldap_account_password }}"
         expected_change: true
     - include_tasks: tasks/auth_source_ldap.yml
       vars:

--- a/tests/test_playbooks/vars/server.yml.example
+++ b/tests/test_playbooks/vars/server.yml.example
@@ -35,6 +35,7 @@ auth_source_ldap_base_dn: dc=example,dc=com
 auth_source_ldap_attr_login: uid
 auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com
 external_usergroup_name: "admins"
+default_auth_source_ldap_account_password: changeme
 
 # Satellite branded params
 satellite_username: "{{ foreman_username }}"


### PR DESCRIPTION
this is required for recording/live in setups where the password is not
"changeme"
