### PR TITLE
testfixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'theforeman/foreman-ansible-modules'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           testing-type: sanity
           pull-request-change-detection: false
           pre-test-cmd: rm -rf tests/fixtures tests/test_playbooks/fixtures
+          coverage: never
 
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,10 @@ jobs:
             ansible: "v2.10.4"
           - python: "3.6"
             ansible: "stable-2.11"
+            container: "python:3.6"
           - python: "3.7"
             ansible: "stable-2.11"
+            container: "python:3.7"
           - python: "3.9"
             ansible: "stable-2.11"
           - python: "3.10"
@@ -90,7 +92,6 @@ jobs:
           for file in /usr/lib/python3/dist-packages/rpm/_rpm*.cpython-*.so; do
             sudo ln -s ${file} $(echo ${file} | sed 's/\.cpython[^.]*//');
           done
-        if: matrix.container == null
       - name: Install Ansible
         run: pip install --upgrade https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz
       - name: Ensure Jinja version is old enough for Ansible 2.10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - stable-2.18
           - devel
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       # Run sanity tests inside a Docker container.
@@ -39,7 +39,7 @@ jobs:
           coverage: never
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
@@ -114,7 +114,7 @@ jobs:
         run: make dist-test
 
   checkmode:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -141,7 +141,7 @@ jobs:
         run: make test-check-mode
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -163,7 +163,7 @@ jobs:
           path: docs/_build/html/
 
   galaxy-importer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -178,7 +178,7 @@ jobs:
         run: make galaxy-importer
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -200,7 +200,7 @@ jobs:
           path: theforeman-foreman-*.tar.gz
 
   execution_environment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'theforeman/foreman-ansible-modules'
     steps:
       - uses: actions/checkout@v4

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -110,7 +110,7 @@ authors:
   - "russianguppie <46544650+russianguppie@users.noreply.github.com>"
   - "willtome <willtome@gmail.com>"
   - "yuqo2450 <79540477+yuqo2450@users.noreply.github.com>"
-version: "5.1.0"
+version: "5.2.0-dev"
 license:
   - "GPL-3.0-or-later"
 tags:

--- a/plugins/callback/foreman.py
+++ b/plugins/callback/foreman.py
@@ -146,7 +146,7 @@ def build_log_foreman(data_list):
                     'source': task.get('name'),
                 },
                 'messages': {
-                    'message': json.dumps(result, sort_keys=True),
+                    'message': json.dumps(result, sort_keys=True, cls=AnsibleNoVaultJSONEncoder),
                 },
                 'level': level,
             }

--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -52,6 +52,11 @@ options:
       - Option to add RAM (only available for VMWare compute-resource)
     required: false
     type: bool
+  quiesce:
+    description:
+      - Option to create quiesce snapshot (only available for VMWare compute-resource)
+    required: false
+    type: bool
   state:
     description:
       - State of Snapshot
@@ -157,6 +162,7 @@ def main():
             description=dict(),
             include_ram=dict(type='bool'),
             id=dict(),
+            quiesce=dict(type='bool'),
         ),
         required_plugins=[('snapshot_management', ['*'])],
         entity_opts={'scope': ['host']},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ import py.path
 import yaml
 
 
+IGNORED_WARNINGS = [
+    "Activation Key 'Test Activation Key Copy' already exists.",
+    "You have configured a plain HTTP server URL. All communication will happen unencrypted.",
+]
+
 TEST_PLAYBOOKS_PATH = py.path.local(__file__).realpath() / '..' / 'test_playbooks'
 
 
@@ -110,3 +115,13 @@ def get_ansible_version():
         except pkg_resources.DistributionNotFound:
             pass
     return ansible_version
+
+
+def assert_no_warnings(run):
+    for event in run.events:
+        # check for play level warnings
+        assert not event.get('event_data', {}).get('warning', False)
+
+        # check for task level warnings
+        event_warnings = [warning for warning in event.get('event_data', {}).get('res', {}).get('warnings', []) if warning not in IGNORED_WARNINGS]
+        assert [] == event_warnings, str(event_warnings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,4 +124,4 @@ def assert_no_warnings(run):
 
         # check for task level warnings
         event_warnings = [warning for warning in event.get('event_data', {}).get('res', {}).get('warnings', []) if warning not in IGNORED_WARNINGS]
-        assert [] == event_warnings, str(event_warnings)
+        assert not event_warnings

--- a/tests/fixtures/callback/dir_store/foreman/testhost-report.json
+++ b/tests/fixtures/callback/dir_store/foreman/testhost-report.json
@@ -73,7 +73,7 @@
         "log": {
           "level": "info",
           "messages": {
-            "message": "{\"ansible_facts\": {\"geheim\": \"admin\"}, \"changed\": false, \"failed\": false, \"module\": \"set_fact\"}"
+            "message": "{\"ansible_facts\": {\"crypt\": \"ENCRYPTED_VAULT_VALUE_NOT_REPORTED\", \"geheim\": \"admin\", \"unsafe\": \"THIS IS {{ crypt }}\\n\"}, \"changed\": false, \"failed\": false, \"module\": \"set_fact\"}"
           },
           "sources": {
             "source": "Vault fact"

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -59,6 +59,8 @@ def run_callback(tmpdir, report_type, vcrmode):
     run = run_playbook_callback(tmpdir, report_type)
     assert run.rc == 0
     assert len(tmpdir.listdir()) > 0, "Directory with results is empty"
+    fixture_directory = os.path.join(os.getcwd(), 'tests', 'fixtures', 'callback', 'dir_store', report_type)
+    assert len(tmpdir.listdir()) == len(os.listdir(fixture_directory)), "Fixture directory and output directory have a different number of files"
     for real_file in tmpdir.listdir(sort=True):
         contents = real_file.read()
         contents = re.sub(r"\d+-\d+-\d+ \d+:\d+:\d+\+\d+:\d+", "2000-01-01 12:00:00+00:00", contents)
@@ -80,7 +82,7 @@ def run_callback(tmpdir, report_type, vcrmode):
             real_contents['metrics']['time']['total'] = 1
             real_contents = drop_incompatible_items(real_contents)
         fixture_name = real_file.basename
-        fixture = os.path.join(os.getcwd(), 'tests', 'fixtures', 'callback', 'dir_store', report_type, fixture_name)
+        fixture = os.path.join(fixture_directory, fixture_name)
         if vcrmode == "record":
             print("Writing: ", str(fixture))
             with open(fixture, 'w') as f:

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from distutils.version import LooseVersion
 
-from .conftest import run_playbook, get_ansible_version
+from .conftest import run_playbook, get_ansible_version, assert_no_warnings
 
 
 def run_playbook_callback(tmpdir, report_type):
@@ -61,6 +61,7 @@ def run_callback(tmpdir, report_type, vcrmode):
     assert len(tmpdir.listdir()) > 0, "Directory with results is empty"
     fixture_directory = os.path.join(os.getcwd(), 'tests', 'fixtures', 'callback', 'dir_store', report_type)
     assert len(tmpdir.listdir()) == len(os.listdir(fixture_directory)), "Fixture directory and output directory have a different number of files"
+    assert_no_warnings(run)
     for real_file in tmpdir.listdir(sort=True):
         contents = real_file.read()
         contents = re.sub(r"\d+-\d+-\d+ \d+:\d+:\d+\+\d+:\d+", "2000-01-01 12:00:00+00:00", contents)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -7,12 +7,7 @@ try:
 except ImportError:
     from distutils.version import LooseVersion
 
-from .conftest import TEST_PLAYBOOKS, INVENTORY_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version
-
-IGNORED_WARNINGS = [
-    "Activation Key 'Test Activation Key Copy' already exists.",
-    "You have configured a plain HTTP server URL. All communication will happen unencrypted.",
-]
+from .conftest import TEST_PLAYBOOKS, INVENTORY_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version, assert_no_warnings
 
 ANSIBLE_SUPPORTS_MODULE_DEFAULTS = LooseVersion(get_ansible_version()) >= LooseVersion('2.12')
 
@@ -35,7 +30,7 @@ def test_crud(tmpdir, module, vcrmode):
         run = run_playbook_vcr(tmpdir, module, record=record)
     assert run.rc == 0
 
-    _assert_no_warnings(run)
+    assert_no_warnings(run)
 
 
 @pytest.mark.parametrize('module', TEST_PLAYBOOKS)
@@ -47,7 +42,7 @@ def test_check_mode(tmpdir, module):
     run = run_playbook_vcr(tmpdir, module, check_mode=True)
     assert run.rc == 0
 
-    _assert_no_warnings(run)
+    assert_no_warnings(run)
 
 
 @pytest.mark.parametrize('module', INVENTORY_PLAYBOOKS)
@@ -59,14 +54,4 @@ def test_inventory(tmpdir, module):
     run = run_playbook(module, inventory=inventory)
     assert run.rc == 0
 
-    _assert_no_warnings(run)
-
-
-def _assert_no_warnings(run):
-    for event in run.events:
-        # check for play level warnings
-        assert not event.get('event_data', {}).get('warning', False)
-
-        # check for task level warnings
-        event_warnings = [warning for warning in event.get('event_data', {}).get('res', {}).get('warnings', []) if warning not in IGNORED_WARNINGS]
-        assert [] == event_warnings, str(event_warnings)
+    assert_no_warnings(run)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -47,7 +47,7 @@ def test_check_mode(tmpdir, module):
 
 @pytest.mark.parametrize('module', INVENTORY_PLAYBOOKS)
 def test_inventory(tmpdir, module):
-    if sys.version_info < (3, 6) and 'GITHUB_ACTIONS' in os.environ.keys():
+    if sys.version_info < (3, 8) and 'GITHUB_ACTIONS' in os.environ.keys():
         pytest.skip("Inventory tests currently don't work inside a container, but Python {}.{} tests require a container on GHA."
                     .format(sys.version_info.major, sys.version_info.minor))
     inventory = [os.path.join(os.getcwd(), 'tests', 'inventory', inv) for inv in ['hosts', "{}.foreman.yml".format(module)]]

--- a/tests/test_playbooks/external_usergroup.yml
+++ b/tests/test_playbooks/external_usergroup.yml
@@ -20,6 +20,7 @@
       vars:
         auth_source_ldap_state: present
         auth_source_ldap_tls: false
+        auth_source_ldap_account_password: "{{ default_auth_source_ldap_account_password }}"
     - include_tasks: tasks/external_usergroup.yml
       vars:
         external_usergroup_state: absent

--- a/tests/test_playbooks/hostgroup.yml
+++ b/tests/test_playbooks/hostgroup.yml
@@ -83,7 +83,7 @@
         compute_resource_organizations: "{{ hostgroup.organizations }}"
         compute_resource_locations: "{{ hostgroup.locations }}"
         compute_resource_provider: 'libvirt'
-        compute_resource_provider_params: "{{ hostgroup.compute_resource.params }}"
+        compute_resource_provider_params: "{{ libvirt.compute_resource.params }}"
         compute_resource_state: present
     - include_tasks: tasks/compute_profile.yml
       vars:

--- a/tests/test_playbooks/hostgroup.yml
+++ b/tests/test_playbooks/hostgroup.yml
@@ -75,6 +75,7 @@
           - "{{ hostgroup.os.name }} {{ hostgroup.os.major }}.{{ hostgroup.os.minor }}"
         installation_medium_locations: "{{ hostgroup.locations }}"
         installation_medium_organizations: "{{ hostgroup.organizations }}"
+        installation_medium_path: "https://mirror.example.com/{{ hostgroup.os.name }}/"
         installation_medium_state: present
     - include_tasks: tasks/compute_resource.yml
       vars:

--- a/tests/test_playbooks/smart_proxy.yml
+++ b/tests/test_playbooks/smart_proxy.yml
@@ -42,7 +42,7 @@
         expected_change: true
         expected_diff: true
         expected_diff_before: "{}"
-        expected_diff_after: "{{ foreman_proxy }}"
+        expected_diff_after: "{{ foreman_proxy | upper }}"
     - include_tasks: tasks/smart_proxy.yml
       vars:
         smart_proxy_state: present
@@ -52,7 +52,7 @@
         smart_proxy_state: absent
         expected_change: true
         expected_diff: true
-        expected_diff_before: "{{ foreman_proxy }}"
+        expected_diff_before: "{{ foreman_proxy | upper }}"
         expected_diff_after: "{}"
     - include_tasks: tasks/smart_proxy.yml
       vars:

--- a/tests/test_playbooks/tasks/external_usergroup.yml
+++ b/tests/test_playbooks/tasks/external_usergroup.yml
@@ -1,7 +1,6 @@
 ---
 - name: "Ensure external usergroup '{{ external_usergroup_name }}' is {{ external_usergroup_state }}"
   vars:
-    external_usergroup_name: "admins"
     external_usergroup_state: present
   external_usergroup:
     username: "{{ foreman_username }}"

--- a/tests/test_playbooks/tasks/smart_proxy.yml
+++ b/tests/test_playbooks/tasks/smart_proxy.yml
@@ -2,7 +2,7 @@
 - name: "Ensure Smart Proxy '{{ smart_proxy_name }}' is {{ smart_proxy_state }}"
   vars:
     smart_proxy_name: "Smart Proxy"
-    smart_proxy_url: "https://{{ foreman_proxy }}:9090"
+    smart_proxy_url: "https://{{ foreman_proxy | upper }}:9090"
   smart_proxy:
     username: "{{ foreman_username }}"
     password: "{{ foreman_password }}"

--- a/tests/test_playbooks/tasks/wait_for_task.yml
+++ b/tests/test_playbooks/tasks/wait_for_task.yml
@@ -7,10 +7,10 @@
     validate_certs: "{{ foreman_validate_certs }}"
     resource: foreman_tasks
     search: "(label = Actions::Katello::Product::Destroy and action ~ 'Test Product' and state = running)"
-  register: tasks
+  register: tasks_list
 - assert:
     fail_msg: "Verification that tasks are runing"
-    that: tasks.resources | length > 0
+    that: tasks_list.resources | length > 0
 
 - name: wait for the task to finish
   wait_for_task:
@@ -20,7 +20,7 @@
     validate_certs: "{{ foreman_validate_certs }}"
     task: "{{ item }}"
     timeout: 900
-  loop: "{{ tasks.resources | map(attribute='id') | list }}"
+  loop: "{{ tasks_list.resources | map(attribute='id') | list }}"
 
 - name: "Search for previously created task"
   resource_info:
@@ -30,8 +30,8 @@
     validate_certs: "{{ foreman_validate_certs }}"
     resource: foreman_tasks
     search: "(label = Actions::Katello::Product::Destroy and action ~ 'Test Product' and state = running)"
-  register: tasks
+  register: tasks_list
 - assert:
     fail_msg: "Verification that no task is runing anymore"
-    that: tasks.resources | length == 0
+    that: tasks_list.resources | length == 0
 ...

--- a/tests/test_playbooks/vars/hostgroup.yml
+++ b/tests/test_playbooks/vars/hostgroup.yml
@@ -16,8 +16,6 @@ hostgroup:
     minor: 6
   compute_resource:
     name: 'libvirt-cr'
-    params:
-      url: "qemu:///system"
   compute_profile:
     name: 'myprofile'
   domains:


### PR DESCRIPTION
- **Bump version to 5.2.0-dev**
- **Add Quiesce option in Snapshot module**
- **Fix _assert_no_warnings(run) in test_crud**
- **Fix exception when serializing results to json**
- **disable coverage in the shared ansible action**
- **Compare number of created files with number of fixtures**
- **also assert that there are no warnings in callback tests**
- **simplify warnings assertion code**
- **Run CI jobs on Ubuntu 24.04**
- **Run Python 3.6 and 3.7 in a container as Ubuntu 24.04 doesn't have them**
- **explicitly set a mirror when creating install medium for hostgroup**
- **use the libvirt CR url defined in compute_profile.yml**
