### PR TITLE
Bugfixes

### DIFF
--- a/changelogs/fragments/auth_sources_ldap.yml
+++ b/changelogs/fragments/auth_sources_ldap.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - The auth_sources_ldap role is sending incompatible parameters when the server_type is active_directory
+...

--- a/changelogs/fragments/lifecycle_environments.yml
+++ b/changelogs/fragments/lifecycle_environments.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix the Lifecycle environments role so the loop is correctly defined.
+...

--- a/roles/auth_sources_ldap/tasks/main.yml
+++ b/roles/auth_sources_ldap/tasks/main.yml
@@ -24,7 +24,7 @@
     port: "{{ item.port | default(omit) }}"
     server_type: "{{ item.server_type | default(omit) }}"
     ldap_filter: "{{ item.ldap_filter | default(omit) }}"
-    use_netgroups: "{{ item.use_netgroups | default(omit) }}"
+    use_netgroups: "{{ omit if item.server_type is match('active_directory') else item.use_netgroups | default(omit) }}"
     state: "{{ item.state | default('present') }}"
   loop: "{{ satellite_auth_sources_ldap }}"
   no_log: "{{ item.account_password is defined }}"

--- a/roles/lifecycle_environments/tasks/main.yml
+++ b/roles/lifecycle_environments/tasks/main.yml
@@ -11,5 +11,5 @@
     prior: "{{ item.prior }}"
     label: "{{ item.label | default(omit) }}"
     state: "{{ item.state | default('present') }}"
-  with_items:
-    - "{{ satellite_lifecycle_environments }}"
+  loop: "{{ satellite_lifecycle_environments }}"
+...


### PR DESCRIPTION
- Fix the `lifecycle_environments` role so the loop is correctly defined
- The `auth_sources_ldap` role is sending incompatible parameters when the `server_type` is `active_directory`