### PR TITLE
Set requires_ansible to >=2.16.0 to pass certification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -194,4 +194,4 @@ plugin_routing:
       redirect: redhat.satellite.sync_plan
     katello_upload:
       redirect: redhat.satellite.content_upload
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'


### PR DESCRIPTION
We still test older Ansible releases, so this is not a breaking change